### PR TITLE
Added: file path completion on tab press.

### DIFF
--- a/completer.py
+++ b/completer.py
@@ -1,0 +1,41 @@
+'''
+Readline path completer, modified snippet from:
+https://stackoverflow.com/questions/5637124/tab-completion-in-pythons-raw-input
+'''
+
+import os
+import readline
+
+def _listdir(root):
+   ''' List directory 'root' appending the path separator to subdirs. '''
+   res = []
+   for name in os.listdir(root):
+      path = os.path.join(root, name)
+      if os.path.isdir(path):
+         name += os.sep
+      res.append(name)
+   return res
+
+def _complete_path(path=None):
+   ''' Perform completion of filesystem path. '''
+   if not path:
+      return _listdir('.')
+
+   dirname, rest = os.path.split(path)
+   tmp = dirname if dirname else '.'
+   res = [os.path.join(dirname, p) for p in _listdir(tmp) if p.startswith(rest)]
+
+   # more than one match, or single match which does not exist (typo)
+   if len(res) > 1 or not os.path.exists(path):
+      return res
+   # resolved to a single directory, so return list of files below it
+
+   if os.path.isdir(path):
+      return [os.path.join(path, p) for p in _listdir(path)]
+
+   # exact file match terminates this completion
+   return [path + ' ']
+
+def complete(text, state):
+   buffer = readline.get_line_buffer()
+   return (_complete_path(buffer)+[None])[state]

--- a/featherduster.py
+++ b/featherduster.py
@@ -6,7 +6,8 @@ FeatherDuster is a tool for brushing away magical crypto fairy dust.
 '''
 
 import sys
-import glob
+import readline
+import completer
 from ishell.console import Console
 from ishell.command import Command
 
@@ -29,7 +30,11 @@ import cryptanalib as ca
 # import
 class ImportMultiFileCommand(Command):
    def run(self, line):
-      # TODO: open a subconsole or just use readline to get filename w tab complete
+      ishellCompleter = readline.get_completer()
+      readline.set_completer_delims(' \t\n;')
+      readline.parse_and_bind("tab: complete")
+      readline.set_completer(completer.complete)
+
       sample_file = raw_input('Please enter the filename you want to open: ')
       try:
          sample_fh = open(sample_file,'r')
@@ -38,10 +43,16 @@ class ImportMultiFileCommand(Command):
          feathermodules.samples = filter(lambda x: x != '' and x != None, feathermodules.samples)
       except:
          print 'Something went wrong. Sorry! Please try again.'
+      finally:
+         readline.set_completer(ishellCompleter)
 
 class ImportSingleFileCommand(Command):
    def run(self, line):
-      # TODO: open a subconsole or just use readline to get filename w tab complete
+      ishellCompleter = readline.get_completer()
+      readline.set_completer_delims(' \t\n;')
+      readline.parse_and_bind("tab: complete")
+      readline.set_completer(completer.complete)
+
       sample_file = raw_input('Please enter the filename you want to open: ')
       try:
          sample_fh = open(sample_file,'r')
@@ -49,6 +60,8 @@ class ImportSingleFileCommand(Command):
          sample_fh.close()
       except:
          print 'Something went wrong. Sorry! Please try again.'
+      finally:
+         readline.set_completer(ishellCompleter)
 
 class ImportManualEntryCommand(Command):
    def run(self, line):


### PR DESCRIPTION
On (single/multi) file import command, ishell completion is replaced by file path completion.
Then whether the sample is correct or not, re-enables ishell completion for next command.
File path completion is performed through a modified snippet taken from:
https://stackoverflow.com/questions/5637124/tab-completion-in-pythons-raw-input
which is added in a new file completer.py, imported from featherduster.py.

--

Hi, long time no see.
Sorry for the delay last months have been way too busy, but I guess better late than never.
This should fix issue #15 that I have open long ago.
All tests from test directory seem to pass on my machine.

Cheers,
Maxime