### PR TITLE
Fix for column_trans exception when treating ints as str

### DIFF
--- a/feathermodules/classical/columnar_transposition.py
+++ b/feathermodules/classical/columnar_transposition.py
@@ -8,7 +8,7 @@ def break_columnar_transposition(ciphertexts):
       results.append(ca.break_columnar_transposition(ciphertext, num_answers=int(arguments['num_answers'])))
    print 'Best results of columnar transposition solve:'
    print '-'*80
-   print '\n'.join(results)
+   print '\n'.join(str(v) for v in results)
    return results
 
 


### PR DESCRIPTION
Referencing this bug:
https://github.com/nccgroup/featherduster/issues/57

Caused an exception due to treating int as a string.