### PR TITLE
Tidy Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,18 @@
-# Use the official Docker Hub Ubuntu 14.04 base image
-FROM debian:jessie
+FROM ubuntu:xenial
 
-#Update and install deps
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -qq && apt-get install -qq \
         build-essential \
-        git \ 
         libncurses-dev \
         libgmp3-dev \
         python-crypto \
         python-dev \
+        python-pip \
         python-setuptools \
     && rm -rf /var/lib/apt/lists/*
 
-#Clone latest Featherduster
-RUN git clone https://github.com/nccgroup/featherduster.git 
-RUN mv featherduster /opt/. 
+COPY . /opt/featherduster
 WORKDIR /opt/featherduster
-RUN python setup.py install
-COPY . .
+RUN pip install -U pip
+RUN pip install .
 
-# Load the entrypoint script to be run later
-#RUN ["cd /opt/featherduster && python featherduster.py"]
 ENTRYPOINT ["python", "/opt/featherduster/featherduster/featherduster.py"]


### PR DESCRIPTION
Previously, Dockerfile contained unnecessary (and sometimes misleading)
comments, extra steps, and commented out commands.

Now, it has been tidied.

Summary of changes:
* Base Docker image is now ubuntu:xenial
  * Before this change, the comment stated that it was using Ubuntu,
while actually pulling debian:jesse
* APT commands are run quietly
* Docker's COPY mechanism is being used, instead of cloning the source
* pip is being used for installation, instead of setup.py

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>