### PR TITLE
Improve Travis CI efficiency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,19 @@
-language:
-  - python
+---
+dist: trusty
+sudo: false
 
-python:
-  - "2.7"
+language: python
+python: '2.7'
+cache: pip
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
+matrix:
+  fast-finish: true
 
-before_install:
-  - sudo apt-get install libgmp-dev
+env:
+  - TEST_RUN='./tests/travis_python_tests'
+  - TEST_RUN='./tests/travis_shell_tests'
 
 install:
-  - python setup.py install
+  - pip install -U .
 
-script:
-  - python -c 'from tests import *'
-  - for test in tests/*.sh; do sh $test; done
+script: "$TEST_RUN"

--- a/tests/travis_python_tests
+++ b/tests/travis_python_tests
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python -c 'from tests import *'

--- a/tests/travis_shell_tests
+++ b/tests/travis_shell_tests
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for test in tests/*.sh; do
+    sh $test
+done


### PR DESCRIPTION
Various efficiency changes such as:

* Force trusty and no sudo
  * This gives us an Ubuntu 14.04 Docker container
    * Required for correct GCC version
* Switch to pip installation
  * APT addon is no longer necessary
* Cache pip packages
  * This will save time on pip installs in subsequent runs
  * Caching is not available for APT packages
* Use Travis CI's matrix feature for parallelism
  * Python and shell tests are still grouped together
    * In the future, all tests can be run in parallel

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>