### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/cryptanalib/classical.py
+++ b/cryptanalib/classical.py
@@ -249,7 +249,7 @@ def evaluate_vigenere_key_length(ciphertext, max_length):
             repeat = True
             break
 
-   # Change priority order if neccessary
+   # Change priority order if necessary
    if not key_length == key_length_best_guesses[0]:
       key_length_best_guesses.remove(key_length)
       key_length_best_guesses.insert(0, key_length)
@@ -307,7 +307,7 @@ def count_up(ll_indices, list_of_lists):
          # As soon as no carry overflow happens: stop increasing
          return ll_indices
       else:
-         # Carry overfow to the next digit
+         # Carry overflow to the next digit
          ll_indices[digit] = 0
          digit += 1
          continue

--- a/cryptanalib/helpers.py
+++ b/cryptanalib/helpers.py
@@ -492,7 +492,7 @@ def detect_plaintext(candidate_text, pt_freq_table=frequency.frequency_tables['e
 def generate_optimized_charset_from_frequency(freq_table, include_zero_freq=False):
    '''
    Given a character frequency table such as those returned by generate_frequency_table(),
-   return a string with only single characters sorted by frequency of occurance descending
+   return a string with only single characters sorted by frequency of occurrence descending
    '''
    # Filter out frequency items to only single characters
    single_char_freq_table = dict(filter(lambda x: len(x[0])==1, freq_table.items()))

--- a/cryptanalib/modern.py
+++ b/cryptanalib/modern.py
@@ -29,7 +29,7 @@ import urllib
 def lcg_recover_parameters(states, a=None, c=None, m=None):
     '''
     Given the observed output of a Linear Congruential Generator
-    calculates the modulus, the mutiplier, and the addend.
+    calculates the modulus, the multiplier, and the addend.
 
     Modulus recovery relies on the property that, given a set of
     numbers
@@ -324,8 +324,8 @@ def wiener(N, e, minutes=10, verbose=False):
 
    Developed by Maxime Puys.
 
-   N - interger, modulus of the RSA key to factor using Wiener's attack.
-   e - interger, public exponent of the RSA key.
+   N - integer, modulus of the RSA key to factor using Wiener's attack.
+   e - integer, public exponent of the RSA key.
    minutes - number of minutes to run the algorithm before giving up
    verbose - (bool) Periodically show how many iterations have been
    """

--- a/tests/testbench_vigenere.py
+++ b/tests/testbench_vigenere.py
@@ -72,7 +72,7 @@ def test_run(plaintext_len, key_len, key = ""):
             score /= float(len(key))
             #print "  Length is correct, key is recovered %d/%d" % (key_score, len(key))
         elif len(key_guess) % len(key) == 0:
-            #print "  Multiple of the key lenght: %d instead of %d" % (len(key_guess), len(key))
+            #print "  Multiple of the key length: %d instead of %d" % (len(key_guess), len(key))
             pass
         else:
             score = 0.0


### PR DESCRIPTION
There are small typos in:
- cryptanalib/classical.py
- cryptanalib/helpers.py
- cryptanalib/modern.py
- tests/testbench_vigenere.py

Fixes:
- Should read `overflow` rather than `overfow`.
- Should read `occurrence` rather than `occurance`.
- Should read `necessary` rather than `neccessary`.
- Should read `multiplier` rather than `mutiplier`.
- Should read `length` rather than `lenght`.
- Should read `integer` rather than `interger`.

Closes #89