### PR TITLE
Fixed Dockerfile: curl and pip 20.3.4 added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,13 @@ RUN apt-get update -qq && apt-get install -qq \
         python-dev \
         python-pip \
         python-setuptools \
+	curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /opt/featherduster
 WORKDIR /opt/featherduster
+RUN curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py
+RUN python get-pip.py
 RUN pip install -U pip
 RUN pip install .
 


### PR DESCRIPTION
Hi, amazing Project! 
I had some problems with the Dockerfile, seems like the installed version of pip is no longer supported. 
As mention in the Title I added cURL for the pip 20.3.4 installation, after that  everything worked fine for me.  